### PR TITLE
Refactor bridge and capability handling for LG ThinQ

### DIFF
--- a/LG ThinQ Device/capabilities/catalog.json
+++ b/LG ThinQ Device/capabilities/catalog.json
@@ -1,0 +1,151 @@
+{
+  "fallback": ["ac.json"],
+  "rules": [
+    {
+      "description": "Air Conditioner",
+      "files": ["ac.json"],
+      "match": {"any": ["air", "condition", "hvac", "ac"]}
+    },
+    {
+      "description": "Refrigerator",
+      "files": ["fridge.json"],
+      "match": {"any": ["fridge", "refrigerator", "freezer"]}
+    },
+    {
+      "description": "Washer",
+      "files": ["washer.json"],
+      "match": {"any": ["wash", "laundry", "dish"]}
+    },
+    {
+      "description": "WashTower Washer",
+      "files": ["washtower_washer.json"],
+      "match": {"all": ["tower", "wash"]}
+    },
+    {
+      "description": "WashCombo",
+      "files": ["washcombo.json"],
+      "match": {"any": ["washcombo", "wash_combo"], "regex": ["combo.*(wash|dry)"]}
+    },
+    {
+      "description": "Mini WashCombo",
+      "files": ["mini_washcombo.json"],
+      "match": {"any": ["mini_washcombo", "mini washcombo", "mini_wash_combo", "miniwashcombo"]}
+    },
+    {
+      "description": "Kimchi Refrigerator",
+      "files": ["kimchi_refrigerator.json"],
+      "match": {"any": ["kimchi"]}
+    },
+    {
+      "description": "Dish Washer",
+      "files": ["dish_washer.json"],
+      "match": {"any": ["dish", "dishwasher", "dish_washer"]}
+    },
+    {
+      "description": "Humidifier",
+      "files": ["humidifier.json"],
+      "match": {"any": ["humidifier", "humid"], "exclude": {"any": ["dehumid", "dehum"]}}
+    },
+    {
+      "description": "Dehumidifier",
+      "files": ["dehumidifier.json"],
+      "match": {"any": ["dehumid", "dehum"], "regex": ["dry.*humid"]}
+    },
+    {
+      "description": "Dryer",
+      "files": ["dryer.json"],
+      "match": {"any": ["dry", "dryer"], "exclude": {"any": ["dehumid", "dehum"]}}
+    },
+    {
+      "description": "WashTower Dryer",
+      "files": ["washtower_dryer.json"],
+      "match": {"all": ["tower"], "any": ["dry", "dryer"]}
+    },
+    {
+      "description": "Water Purifier",
+      "files": ["water_purifier.json"],
+      "match": {"any": ["water purifier", "water_purifier", "waterpurifier"], "regex": ["water.*purifier"]}
+    },
+    {
+      "description": "Air Purifier",
+      "files": ["air_purifier.json"],
+      "match": {"any": ["purifier", "air_purifier", "airpurifier", "puri"], "exclude": {"any": ["water purifier", "water_purifier", "waterpurifier"]}}
+    },
+    {
+      "description": "Air Purifier Fan",
+      "files": ["air_purifier_fan.json"],
+      "match": {"any": ["air_purifier_fan", "purifier_fan"], "regex": ["purifier.*fan"]}
+    },
+    {
+      "description": "Stick Cleaner",
+      "files": ["stick_cleaner.json"],
+      "match": {"any": ["stick", "cordless", "handstick", "stick_cleaner"]}
+    },
+    {
+      "description": "Robot Cleaner",
+      "files": ["robot_cleaner.json"],
+      "match": {"any": ["robot", "vacuum", "cleaner"]},
+      "exclude": {"any": ["stick", "handstick", "stick_cleaner", "cordless"]}
+    },
+    {
+      "description": "Oven",
+      "files": ["oven.json"],
+      "match": {"any": ["oven", "range", "cook"]}
+    },
+    {
+      "description": "Microwave",
+      "files": ["microwave_oven.json"],
+      "match": {"any": ["microwave", "micro_wave"]}
+    },
+    {
+      "description": "Cooktop",
+      "files": ["cooktop.json"],
+      "match": {"any": ["cooktop", "cook_top", "hob", "stove"]}
+    },
+    {
+      "description": "Hood",
+      "files": ["hood.json"],
+      "match": {"any": ["hood", "range_hood", "rangehood", "cooker_hood", "extractor"]}
+    },
+    {
+      "description": "Ventilator",
+      "files": ["ventilator.json"],
+      "match": {"any": ["ventilator", "stand_fan", "standfan", "tower_fan", "towerfan"]}
+    },
+    {
+      "description": "Styler",
+      "files": ["styler.json"],
+      "match": {"any": ["styler", "steam", "closet", "clothing"]}
+    },
+    {
+      "description": "Ceiling Fan",
+      "files": ["ceiling_fan.json"],
+      "match": {"any": ["ceiling", "ceiling_fan", "ceilingfan"]}
+    },
+    {
+      "description": "Wine Cellar",
+      "files": ["wine_cellar.json"],
+      "match": {"any": ["wine", "cellar", "wine_cellar", "winecooler", "wine_cooler"]}
+    },
+    {
+      "description": "Home Brew",
+      "files": ["home_brew.json"],
+      "match": {"any": ["homebrew", "home_brew", "beer"]}
+    },
+    {
+      "description": "Plant Cultivator",
+      "files": ["plant_cultivator.json"],
+      "match": {"any": ["plant", "cultivator", "garden", "grow"]}
+    },
+    {
+      "description": "System Boiler",
+      "files": ["system_boiler.json"],
+      "match": {"any": ["boiler", "system_boiler"], "regex": ["system.*boiler"]}
+    },
+    {
+      "description": "Water Heater",
+      "files": ["water_heater.json"],
+      "match": {"any": ["water_heater", "water heater"], "regex": ["water.*heater"]}
+    }
+  ]
+}

--- a/LG ThinQ Device/libs/CapabilityEngine.php
+++ b/LG ThinQ Device/libs/CapabilityEngine.php
@@ -24,6 +24,9 @@ class CapabilityEngine
     /** @var array<string, mixed> */
     private array $flatStatus = [];
 
+    /** @var array<string, mixed>|null */
+    private static ?array $catalog = null;
+
     public function __construct(int $instanceId, string $baseDir)
     {
         $this->instanceId = $instanceId;
@@ -49,133 +52,7 @@ class CapabilityEngine
      */
     public function loadCapabilities(string $deviceType, array $profile): void
     {
-        $dt = strtolower($deviceType);
-        @IPS_LogMessage('CapabilityEngine', sprintf('loadCapabilities: deviceType="%s", dt="%s"', $deviceType, $dt));
-        $files = [];
-        if ($dt === '' || str_contains($dt, 'air') || str_contains($dt, 'condition') || str_contains($dt, 'hvac') || str_contains($dt, 'ac')) {
-            $files[] = $this->baseDir . '/capabilities/ac.json';
-            @IPS_LogMessage('CapabilityEngine', 'Added ac.json capability file');
-        }
-        if (str_contains($dt, 'fridge') || str_contains($dt, 'refrigerator') || str_contains($dt, 'freezer')) {
-            $files[] = $this->baseDir . '/capabilities/fridge.json';
-        }
-        if (str_contains($dt, 'wash') || str_contains($dt, 'laundry') || str_contains($dt, 'dish')) {
-            $files[] = $this->baseDir . '/capabilities/washer.json';
-        }
-        // Washtower washer detection (load after generic washer to override where needed)
-        if (str_contains($dt, 'washtower') || str_contains($dt, 'wash_tower') || (str_contains($dt, 'tower') && str_contains($dt, 'wash'))) {
-            $files[] = $this->baseDir . '/capabilities/washtower_washer.json';
-        }
-        // WashCombo detection (load after generic washer to override where needed)
-        if (str_contains($dt, 'washcombo') || str_contains($dt, 'wash_combo') || (str_contains($dt, 'combo') && (str_contains($dt, 'wash') || str_contains($dt, 'dry')))) {
-            $files[] = $this->baseDir . '/capabilities/washcombo.json';
-        }
-        // Mini WashCombo detection (load after washcombo to override where needed)
-        if (str_contains($dt, 'mini_washcombo') || str_contains($dt, 'mini washcombo') || str_contains($dt, 'mini_wash_combo') || str_contains($dt, 'miniwashcombo')) {
-            $files[] = $this->baseDir . '/capabilities/mini_washcombo.json';
-        }
-        // Kimchi refrigerator detection (additional to generic fridge)
-        if (str_contains($dt, 'kimchi')) {
-            $files[] = $this->baseDir . '/capabilities/kimchi_refrigerator.json';
-        }
-        // Dishwasher detection (load after washer to override common idents where needed)
-        if (str_contains($dt, 'dish') || str_contains($dt, 'dishwasher') || str_contains($dt, 'dish_washer')) {
-            $files[] = $this->baseDir . '/capabilities/dish_washer.json';
-        }
-        // Humidifier detection (avoid collision with dehumidifier)
-        $isHumidifier = str_contains($dt, 'humidifier') || (str_contains($dt, 'humid') && !str_contains($dt, 'dehumid'));
-        if ($isHumidifier) {
-            $files[] = $this->baseDir . '/capabilities/humidifier.json';
-        }
-        // Dehumidifier detection (avoid collision with dryer)
-        if (str_contains($dt, 'dehumid') || str_contains($dt, 'dehum') || (str_contains($dt, 'dry') && str_contains($dt, 'humid'))) {
-            $files[] = $this->baseDir . '/capabilities/dehumidifier.json';
-        }
-        // Dryer detection
-        if (str_contains($dt, 'dry') || str_contains($dt, 'dryer')) {
-            $files[] = $this->baseDir . '/capabilities/dryer.json';
-        }
-        // Washtower dryer detection (load after generic dryer to override where needed)
-        if (str_contains($dt, 'washtower') || str_contains($dt, 'wash_tower') || (str_contains($dt, 'tower') && (str_contains($dt, 'dry') || str_contains($dt, 'dryer')))) {
-            $files[] = $this->baseDir . '/capabilities/washtower_dryer.json';
-        }
-        // Purifier detection with disambiguation
-        $isWaterPurifier = (str_contains($dt, 'water') && str_contains($dt, 'purifier'))
-            || str_contains($dt, 'water_purifier')
-            || str_contains($dt, 'waterpurifier');
-        if ($isWaterPurifier) {
-            $files[] = $this->baseDir . '/capabilities/water_purifier.json';
-        }
-        $isAirPurifier = (str_contains($dt, 'purifier') || str_contains($dt, 'air_purifier') || str_contains($dt, 'airpurifier') || str_contains($dt, 'puri')) && !$isWaterPurifier;
-        if ($isAirPurifier) {
-            $files[] = $this->baseDir . '/capabilities/air_purifier.json';
-            // Air purifier fan variant (load after standard purifier to override where needed)
-            if (str_contains($dt, 'fan') || str_contains($dt, 'air_purifier_fan') || str_contains($dt, 'purifier_fan')) {
-                $files[] = $this->baseDir . '/capabilities/air_purifier_fan.json';
-            }
-        }
-        // Stick cleaner detection (before robot to avoid overlap)
-        $isStickCleaner = str_contains($dt, 'stick') || str_contains($dt, 'cordless') || str_contains($dt, 'handstick') || str_contains($dt, 'stick_cleaner');
-        if ($isStickCleaner) {
-            $files[] = $this->baseDir . '/capabilities/stick_cleaner.json';
-        }
-        // Robot cleaner detection (exclude stick cleaner)
-        if ((str_contains($dt, 'robot') || str_contains($dt, 'vacuum') || (str_contains($dt, 'cleaner') && !$isStickCleaner)) && !$isStickCleaner) {
-            $files[] = $this->baseDir . '/capabilities/robot_cleaner.json';
-        }
-        // Oven / Range detection
-        if (str_contains($dt, 'oven') || str_contains($dt, 'range') || str_contains($dt, 'cook')) {
-            $files[] = $this->baseDir . '/capabilities/oven.json';
-        }
-        // Microwave oven detection
-        if (str_contains($dt, 'microwave') || str_contains($dt, 'micro_wave')) {
-            $files[] = $this->baseDir . '/capabilities/microwave_oven.json';
-        }
-        // Cooktop / Hob detection
-        if (str_contains($dt, 'cooktop') || str_contains($dt, 'cook_top') || str_contains($dt, 'hob') || str_contains($dt, 'stove')) {
-            $files[] = $this->baseDir . '/capabilities/cooktop.json';
-        }
-        // Hood / Range Hood detection
-        if (str_contains($dt, 'hood') || str_contains($dt, 'range_hood') || str_contains($dt, 'rangehood') || str_contains($dt, 'cooker_hood') || str_contains($dt, 'extractor')) {
-            $files[] = $this->baseDir . '/capabilities/hood.json';
-        }
-        // Ventilator (stand/tower fan) detection
-        if (str_contains($dt, 'ventilator') || str_contains($dt, 'stand_fan') || str_contains($dt, 'standfan') || str_contains($dt, 'tower_fan') || str_contains($dt, 'towerfan')) {
-            $files[] = $this->baseDir . '/capabilities/ventilator.json';
-        }
-        // Styler detection
-        if (str_contains($dt, 'styler') || str_contains($dt, 'steam') || str_contains($dt, 'closet') || str_contains($dt, 'clothing')) {
-            $files[] = $this->baseDir . '/capabilities/styler.json';
-        }
-        // Ceiling fan detection
-        if (str_contains($dt, 'ceiling') || str_contains($dt, 'ceiling_fan') || str_contains($dt, 'ceilingfan')) {
-            $files[] = $this->baseDir . '/capabilities/ceiling_fan.json';
-        }
-        // Wine cellar / wine cooler detection
-        if (str_contains($dt, 'wine') || str_contains($dt, 'cellar') || str_contains($dt, 'wine_cellar') || str_contains($dt, 'winecooler') || str_contains($dt, 'wine_cooler')) {
-            $files[] = $this->baseDir . '/capabilities/wine_cellar.json';
-        }
-        // HomeBrew / Beer maker detection
-        if (str_contains($dt, 'homebrew') || str_contains($dt, 'home_brew') || str_contains($dt, 'beer')) {
-            $files[] = $this->baseDir . '/capabilities/home_brew.json';
-        }
-        // Plant cultivator detection
-        if (str_contains($dt, 'plant') || str_contains($dt, 'cultivator') || str_contains($dt, 'garden') || str_contains($dt, 'grow')) {
-            $files[] = $this->baseDir . '/capabilities/plant_cultivator.json';
-        }
-        // System boiler detection
-        if (str_contains($dt, 'boiler') || str_contains($dt, 'system_boiler') || (str_contains($dt, 'system') && str_contains($dt, 'boiler'))) {
-            $files[] = $this->baseDir . '/capabilities/system_boiler.json';
-        }
-        // Water heater detection
-        if (str_contains($dt, 'water_heater') || str_contains($dt, 'water heater') || (str_contains($dt, 'water') && str_contains($dt, 'heater'))) {
-            $files[] = $this->baseDir . '/capabilities/water_heater.json';
-        }
-        // Fallback: if nothing matched, try AC basic
-        if (empty($files)) {
-            $files[] = $this->baseDir . '/capabilities/ac.json';
-        }
-
+        $files = $this->resolveCapabilityFiles($deviceType, $profile);
         $this->caps = [];
         @IPS_LogMessage('CapabilityEngine', sprintf('Loading %d capability files: %s', count($files), implode(', ', $files)));
         foreach ($files as $f) {
@@ -202,6 +79,157 @@ class CapabilityEngine
             }
         }
         $this->flatProfile = $this->flatten($profile);
+    }
+
+    /**
+     * @param array<string, mixed> $profile
+     * @return array<int, string>
+     */
+    private function resolveCapabilityFiles(string $deviceType, array $profile): array
+    {
+        $catalog = $this->loadCatalog();
+        $type = strtolower((string)$deviceType);
+        $profileText = strtolower(json_encode($profile, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) ?: '');
+
+        $files = [];
+        foreach ($catalog['rules'] as $rule) {
+            if ($this->catalogRuleMatches($rule, $type, $profileText)) {
+                foreach ($rule['files'] as $file) {
+                    $files[] = $this->baseDir . '/capabilities/' . $file;
+                }
+            }
+        }
+        if (empty($files)) {
+            foreach ($catalog['fallback'] as $fallback) {
+                $files[] = $this->baseDir . '/capabilities/' . $fallback;
+            }
+        }
+
+        $files = array_values(array_unique($files));
+        return $files;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadCatalog(): array
+    {
+        if (self::$catalog !== null) {
+            return self::$catalog;
+        }
+        $file = $this->baseDir . '/capabilities/catalog.json';
+        $default = ['rules' => [], 'fallback' => ['ac.json']];
+        if (!@is_file($file)) {
+            self::$catalog = $default;
+            return self::$catalog;
+        }
+        $json = @file_get_contents($file);
+        if (!is_string($json) || $json === '') {
+            self::$catalog = $default;
+            return self::$catalog;
+        }
+        $data = json_decode($json, true);
+        if (!is_array($data) || !isset($data['rules']) || !is_array($data['rules'])) {
+            self::$catalog = $default;
+            return self::$catalog;
+        }
+        foreach ($data['rules'] as &$rule) {
+            if (!isset($rule['files']) || !is_array($rule['files'])) {
+                $rule['files'] = [];
+            }
+        }
+        self::$catalog = $data;
+        return self::$catalog;
+    }
+
+    /**
+     * @param array<string, mixed> $rule
+     */
+    private function catalogRuleMatches(array $rule, string $deviceType, string $profileText): bool
+    {
+        $match = $rule['match'] ?? [];
+        $exclude = $rule['exclude'] ?? [];
+        if (!$this->matchesCondition($match, $deviceType, $profileText)) {
+            return false;
+        }
+        if (!empty($exclude) && $this->matchesCondition($exclude, $deviceType, $profileText)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $condition
+     */
+    private function matchesCondition(array $condition, string $deviceType, string $profileText): bool
+    {
+        if (empty($condition)) {
+            return true;
+        }
+        $haystacks = [$deviceType];
+        if ($profileText !== '') {
+            $haystacks[] = $profileText;
+        }
+
+        if (isset($condition['any']) && is_array($condition['any'])) {
+            $found = false;
+            foreach ($condition['any'] as $needle) {
+                $needle = strtolower((string)$needle);
+                if ($needle === '') {
+                    continue;
+                }
+                foreach ($haystacks as $haystack) {
+                    if (strpos($haystack, $needle) !== false) {
+                        $found = true;
+                        break 2;
+                    }
+                }
+            }
+            if (!$found) {
+                return false;
+            }
+        }
+
+        if (isset($condition['all']) && is_array($condition['all'])) {
+            foreach ($condition['all'] as $needle) {
+                $needle = strtolower((string)$needle);
+                if ($needle === '') {
+                    continue;
+                }
+                $matches = false;
+                foreach ($haystacks as $haystack) {
+                    if (strpos($haystack, $needle) !== false) {
+                        $matches = true;
+                        break;
+                    }
+                }
+                if (!$matches) {
+                    return false;
+                }
+            }
+        }
+
+        if (isset($condition['regex']) && is_array($condition['regex'])) {
+            $regexMatch = false;
+            foreach ($condition['regex'] as $pattern) {
+                $pattern = (string)$pattern;
+                if ($pattern === '') {
+                    continue;
+                }
+                $pattern = '/' . str_replace('/', '\/', $pattern) . '/i';
+                foreach ($haystacks as $haystack) {
+                    if (@preg_match($pattern, $haystack)) {
+                        $regexMatch = true;
+                        break 2;
+                    }
+                }
+            }
+            if (!$regexMatch) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/LG ThinQ Device/module.php
+++ b/LG ThinQ Device/module.php
@@ -74,7 +74,7 @@ class LGThinQDevice extends IPSModule
             $this->SetupDeviceVariables();
 
         } catch (\Throwable $e) {
-
+            $this->logThrowable('SetupDeviceVariables', $e);
         }
 
         // Auto-Subscribe für Event/Push am Bridge-Splitter
@@ -84,6 +84,7 @@ class LGThinQDevice extends IPSModule
                 $this->sendAction('SubscribeDevice', ['DeviceID' => $deviceID, 'Push' => true, 'Event' => true]);
             }
         } catch (\Throwable $e) {
+            $this->logThrowable('AutoSubscribe', $e);
         }
     }
 
@@ -115,8 +116,10 @@ class LGThinQDevice extends IPSModule
             try {
                 $this->getCapabilityEngine()->applyStatus($status);
             } catch (\Throwable $e) {
+                $this->logThrowable('UpdateStatus applyStatus', $e);
             }
         } catch (\Throwable $e) {
+            $this->logThrowable('UpdateStatus', $e);
         }
     }
 
@@ -2289,6 +2292,11 @@ class LGThinQDevice extends IPSModule
         if ($s === '') return '';
         if (strlen($s) <= 4) return substr($s, 0, 1) . '***' . substr($s, -1);
         return substr($s, 0, 2) . '***' . substr($s, -2);
+    }
+
+    private function logThrowable(string $context, \Throwable $e): void
+    {
+        $this->SendDebug($context, $e->getMessage(), 0);
     }
 
 

--- a/LG ThinQ/libs/ThinQConfig.php
+++ b/LG ThinQ/libs/ThinQConfig.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQBridgeConfig
+{
+    public string $accessToken;
+    public string $countryCode;
+    public string $clientId;
+    public bool $debug;
+    public bool $useMqtt;
+    public int $mqttClientId;
+    public string $mqttTopicFilter;
+    public bool $ignoreRetained;
+    public int $eventTtlHours;
+    public int $eventRenewLeadMin;
+
+    /**
+     * @param array<int, string> $errors
+     */
+    private function __construct(
+        string $accessToken,
+        string $countryCode,
+        string $clientId,
+        bool $debug,
+        bool $useMqtt,
+        int $mqttClientId,
+        string $mqttTopicFilter,
+        bool $ignoreRetained,
+        int $eventTtlHours,
+        int $eventRenewLeadMin
+    ) {
+        $this->accessToken = $accessToken;
+        $this->countryCode = $countryCode;
+        $this->clientId = $clientId;
+        $this->debug = $debug;
+        $this->useMqtt = $useMqtt;
+        $this->mqttClientId = $mqttClientId;
+        $this->mqttTopicFilter = $mqttTopicFilter;
+        $this->ignoreRetained = $ignoreRetained;
+        $this->eventTtlHours = $eventTtlHours;
+        $this->eventRenewLeadMin = $eventRenewLeadMin;
+    }
+
+    public static function fromModule(IPSModule $module): self
+    {
+        $accessToken = trim((string)$module->ReadPropertyString('AccessToken'));
+        $countryCode = strtoupper(trim((string)$module->ReadPropertyString('CountryCode')));
+        $debug = (bool)$module->ReadPropertyBoolean('Debug');
+        $useMqtt = (bool)$module->ReadPropertyBoolean('UseMQTT');
+        $mqttClientId = (int)$module->ReadPropertyInteger('MQTTClientID');
+        $mqttTopicFilter = (string)$module->ReadPropertyString('MQTTTopicFilter');
+        $ignoreRetained = (bool)$module->ReadPropertyBoolean('IgnoreRetained');
+        $eventTtlHours = (int)$module->ReadPropertyInteger('EventTTLHrs');
+        $eventRenewLeadMin = (int)$module->ReadPropertyInteger('EventRenewLeadMin');
+
+        $clientIdProperty = trim((string)$module->ReadPropertyString('ClientID'));
+        $clientIdAttr = trim((string)$module->ReadAttributeString('ClientID'));
+        $clientId = $clientIdProperty !== '' ? $clientIdProperty : $clientIdAttr;
+        if ($clientId === '') {
+            $clientId = ThinQHelpers::generateUUIDv4();
+            $module->WriteAttributeString('ClientID', $clientId);
+        } elseif ($clientIdProperty !== '' && $clientIdProperty !== $clientIdAttr) {
+            $module->WriteAttributeString('ClientID', $clientIdProperty);
+        }
+
+        return new self(
+            $accessToken,
+            $countryCode,
+            $clientId,
+            $debug,
+            $useMqtt,
+            $mqttClientId,
+            $mqttTopicFilter,
+            $ignoreRetained,
+            $eventTtlHours,
+            $eventRenewLeadMin
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function validate(): array
+    {
+        $errors = [];
+        if ($this->accessToken === '') {
+            $errors[] = 'AccessToken fehlt.';
+        }
+        if ($this->countryCode === '') {
+            $errors[] = 'CountryCode fehlt.';
+        }
+        if ($this->eventTtlHours < 1 || $this->eventTtlHours > 24) {
+            $errors[] = 'EventTTL muss zwischen 1 und 24 Stunden liegen.';
+        }
+        if ($this->eventRenewLeadMin < 1 || $this->eventRenewLeadMin >= 60) {
+            $errors[] = 'Event Renew Vorlauf muss zwischen 1 und 59 Minuten liegen.';
+        }
+        if ($this->useMqtt && $this->mqttClientId <= 0) {
+            $errors[] = 'Für MQTT Push muss ein gültiger MQTT-Client ausgewählt werden.';
+        }
+        return $errors;
+    }
+
+    public function isValid(): bool
+    {
+        return empty($this->validate());
+    }
+
+    public function baseUrl(): string
+    {
+        $region = self::resolveRegion($this->countryCode);
+        return 'https://api-' . strtolower($region) . '.lgthinq.com/';
+    }
+
+    public static function resolveRegion(string $countryCode): string
+    {
+        $country = strtoupper($countryCode);
+        $eic = ['DE','AT','CH','FR','IT','ES','GB','IE','NL','BE','DK','SE','NO','FI','PL','PT','GR','CZ','HU','RO'];
+        $aic = ['US','CA','AR','BR','CL','CO','MX','PE','UY','VE','PR'];
+        $kic = ['JP','KR','AU','NZ','CN','HK','TW','SG','TH','VN','MY','ID','PH'];
+        if (in_array($country, $eic, true)) {
+            return 'EIC';
+        }
+        if (in_array($country, $aic, true)) {
+            return 'AIC';
+        }
+        if (in_array($country, $kic, true)) {
+            return 'KIC';
+        }
+        return 'KIC';
+    }
+
+    public function normalizedEventTtlHours(): int
+    {
+        return max(1, min(24, $this->eventTtlHours));
+    }
+
+    public function normalizedEventRenewLeadMinutes(): int
+    {
+        return max(1, min(59, $this->eventRenewLeadMin));
+    }
+}

--- a/LG ThinQ/libs/ThinQDeviceRepository.php
+++ b/LG ThinQ/libs/ThinQDeviceRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQDeviceRepository
+{
+    private IPSModule $module;
+
+    public function __construct(IPSModule $module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAll(): array
+    {
+        $raw = (string)$this->module->ReadAttributeString('Devices');
+        $data = json_decode($raw, true);
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $devices
+     */
+    public function saveAll(array $devices): void
+    {
+        $this->module->WriteAttributeString('Devices', json_encode($devices, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function findById(string $deviceId): ?array
+    {
+        foreach ($this->getAll() as $device) {
+            $id = (string)($device['deviceId'] ?? ($device['device_id'] ?? ''));
+            if ($id === $deviceId) {
+                return $device;
+            }
+        }
+        return null;
+    }
+}

--- a/LG ThinQ/libs/ThinQEventManager.php
+++ b/LG ThinQ/libs/ThinQEventManager.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQEventManager
+{
+    private ThinQHttpClient $httpClient;
+    private ThinQEventSubscriptionRepository $repository;
+    private IPSModule $module;
+    private ThinQBridgeConfig $config;
+
+    public function __construct(
+        IPSModule $module,
+        ThinQBridgeConfig $config,
+        ThinQHttpClient $httpClient,
+        ThinQEventSubscriptionRepository $repository
+    ) {
+        $this->module = $module;
+        $this->config = $config;
+        $this->httpClient = $httpClient;
+        $this->repository = $repository;
+    }
+
+    public function subscribe(string $deviceId): bool
+    {
+        try {
+            $ttl = $this->config->normalizedEventTtlHours();
+            $body = ['expire' => ['unit' => 'HOUR', 'timer' => $ttl]];
+            $this->httpClient->request('POST', 'event/' . rawurlencode($deviceId) . '/subscribe', $body);
+            $expiresAt = time() + ($ttl * 3600);
+            $this->repository->updateExpiry($deviceId, $expiresAt);
+            return true;
+        } catch (Throwable $e) {
+            $this->module->SendDebug('Event Subscribe', $e->getMessage(), 0);
+            return false;
+        }
+    }
+
+    public function unsubscribe(string $deviceId): bool
+    {
+        $ok = true;
+        try {
+            $this->httpClient->request('DELETE', 'event/' . rawurlencode($deviceId) . '/unsubscribe');
+        } catch (Throwable $e) {
+            $this->module->SendDebug('Event Unsubscribe', $e->getMessage(), 0);
+            $ok = false;
+        }
+        $this->repository->remove($deviceId);
+        return $ok;
+    }
+
+    public function renewExpiring(): void
+    {
+        $subs = $this->repository->getAll();
+        $leadSeconds = $this->config->normalizedEventRenewLeadMinutes() * 60;
+        $now = time();
+        foreach (array_keys($subs) as $deviceId) {
+            $deviceId = (string)$deviceId;
+            if ($deviceId === '') {
+                continue;
+            }
+            $expiresAt = (int)($subs[$deviceId]['expiresAt'] ?? 0);
+            if ($expiresAt === 0 || ($expiresAt - $leadSeconds) <= $now) {
+                $this->subscribe($deviceId);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function listSubscriptions(): array
+    {
+        return $this->repository->getAll();
+    }
+
+    public function clear(): void
+    {
+        $this->repository->saveAll([]);
+    }
+}

--- a/LG ThinQ/libs/ThinQEventPipeline.php
+++ b/LG ThinQ/libs/ThinQEventPipeline.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQEventPipeline
+{
+    /** @var array<int, callable> */
+    private array $eventHandlers = [];
+    /** @var array<int, callable> */
+    private array $metaHandlers = [];
+
+    public function onEvent(callable $handler): void
+    {
+        $this->eventHandlers[] = $handler;
+    }
+
+    public function onMeta(callable $handler): void
+    {
+        $this->metaHandlers[] = $handler;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function dispatchEvent(string $deviceId, array $payload): void
+    {
+        foreach ($this->eventHandlers as $handler) {
+            $handler($deviceId, $payload);
+        }
+    }
+
+    public function dispatchMeta(string $type, string $deviceId, array $payload): void
+    {
+        foreach ($this->metaHandlers as $handler) {
+            $handler($type, $deviceId, $payload);
+        }
+    }
+}

--- a/LG ThinQ/libs/ThinQEventSubscriptionRepository.php
+++ b/LG ThinQ/libs/ThinQEventSubscriptionRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQEventSubscriptionRepository
+{
+    private IPSModule $module;
+
+    public function __construct(IPSModule $module)
+    {
+        $this->module = $module;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function getAll(): array
+    {
+        $raw = (string)$this->module->ReadAttributeString('EventSubscriptions');
+        $data = json_decode($raw, true);
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $subs
+     */
+    public function saveAll(array $subs): void
+    {
+        $this->module->WriteAttributeString('EventSubscriptions', json_encode($subs, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    public function updateExpiry(string $deviceId, int $expiresAt): void
+    {
+        $subs = $this->getAll();
+        $subs[$deviceId]['expiresAt'] = $expiresAt;
+        $this->saveAll($subs);
+    }
+
+    public function remove(string $deviceId): void
+    {
+        $subs = $this->getAll();
+        if (isset($subs[$deviceId])) {
+            unset($subs[$deviceId]);
+            $this->saveAll($subs);
+        }
+    }
+}

--- a/LG ThinQ/libs/ThinQHelpers.php
+++ b/LG ThinQ/libs/ThinQHelpers.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQHelpers
+{
+    public static function generateMessageId(): string
+    {
+        $bytes = random_bytes(16);
+        $base = rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+        return $base;
+    }
+
+    public static function generateUUIDv4(): string
+    {
+        $data = random_bytes(16);
+        $data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
+        $data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+}

--- a/LG ThinQ/libs/ThinQHttpClient.php
+++ b/LG ThinQ/libs/ThinQHttpClient.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQHttpClient
+{
+    private IPSModule $module;
+    private ThinQBridgeConfig $config;
+    private string $apiKey;
+
+    public function __construct(IPSModule $module, ThinQBridgeConfig $config, string $apiKey)
+    {
+        $this->module = $module;
+        $this->config = $config;
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @param array<string, mixed>|null $payload
+     * @param array<int, string> $extraHeaders
+     * @return array<string, mixed>
+     */
+    public function request(string $method, string $endpoint, ?array $payload = null, array $extraHeaders = []): array
+    {
+        $errors = $this->config->validate();
+        if (!empty($errors)) {
+            throw new Exception('ThinQ Konfiguration unvollständig: ' . implode(' ', $errors));
+        }
+
+        $url = $this->config->baseUrl() . ltrim($endpoint, '/');
+        $headers = [
+            'Authorization: Bearer ' . $this->config->accessToken,
+            'x-country: ' . $this->config->countryCode,
+            'x-message-id: ' . ThinQHelpers::generateMessageId(),
+            'x-client-id: ' . $this->config->clientId,
+            'x-api-key: ' . $this->apiKey,
+            'x-service-phase: OP',
+            'Content-Type: application/json'
+        ];
+        foreach ($extraHeaders as $header) {
+            if ($header !== '') {
+                $headers[] = $header;
+            }
+        }
+
+        $method = strtoupper($method);
+        $body = ($method !== 'GET' && $payload !== null)
+            ? json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+            : '';
+
+        $this->module->SendDebug('HTTP Request', $method . ' ' . $url, 0);
+        if ($this->config->debug) {
+            $this->module->SendDebug('HTTP Headers', json_encode($headers, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), 0);
+            if ($method !== 'GET') {
+                $this->module->SendDebug('HTTP Body', $body, 0);
+            }
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => $method,
+                'header' => implode("\r\n", $headers),
+                'ignore_errors' => true,
+                'timeout' => 15,
+                'protocol_version' => 1.1,
+                'content' => $method !== 'GET' ? $body : null
+            ]
+        ]);
+
+        $result = @file_get_contents($url, false, $context);
+        if ($result === false || $result === null) {
+            $error = error_get_last();
+            throw new Exception('HTTP Fehler beim Aufruf von ' . $url . ': ' . ($error['message'] ?? 'unbekannt'));
+        }
+
+        $statusHeader = $http_response_header[0] ?? '';
+        $statusCode = 0;
+        if (preg_match('/HTTP\/[0-9.]+\s+(\d+)/', $statusHeader, $match)) {
+            $statusCode = (int)$match[1];
+        }
+
+        if ($statusCode === 204 || trim($result) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($result, true);
+        if ($statusCode >= 400) {
+            if (is_array($decoded) && isset($decoded['error'])) {
+                $code = $decoded['error']['code'] ?? 'unknown';
+                $message = $decoded['error']['message'] ?? 'unknown';
+                throw new Exception('HTTP ' . $statusCode . ' API Fehler ' . $code . ': ' . $message . ' (' . $url . ')');
+            }
+            $snippet = substr(preg_replace('/\s+/', ' ', (string)$result), 0, 300);
+            throw new Exception('HTTP ' . $statusCode . ' Fehler von ' . $url . ': ' . $snippet);
+        }
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        return $decoded['response'] ?? $decoded;
+    }
+}

--- a/LG ThinQ/libs/ThinQMqttRouter.php
+++ b/LG ThinQ/libs/ThinQMqttRouter.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+final class ThinQMqttRouter
+{
+    private IPSModule $module;
+    private ThinQBridgeConfig $config;
+    private ThinQEventPipeline $pipeline;
+
+    public function __construct(IPSModule $module, ThinQBridgeConfig $config, ThinQEventPipeline $pipeline)
+    {
+        $this->module = $module;
+        $this->config = $config;
+        $this->pipeline = $pipeline;
+    }
+
+    public function handle(string $json): void
+    {
+        $this->module->SendDebug('ReceiveData', $json, 0);
+        $raw = json_decode($json, true);
+        if (!is_array($raw)) {
+            return;
+        }
+
+        $env = $this->extractEnvelope($raw);
+        $topic = (string)($env['Topic'] ?? ($env['topic'] ?? ''));
+        $retain = (bool)($env['Retain'] ?? ($env['retain'] ?? false));
+        if ($this->config->ignoreRetained && $retain) {
+            $this->module->SendDebug('MQTT', 'Ignore retained: ' . $topic, 0);
+            return;
+        }
+
+        $filter = (string)$this->config->mqttTopicFilter;
+        if ($filter !== '' && !$this->topicMatches($topic, $filter)) {
+            return;
+        }
+
+        $payloadRaw = $env['Payload'] ?? ($env['payload'] ?? null);
+        $payload = [];
+        if (is_string($payloadRaw)) {
+            $payload = json_decode($payloadRaw, true) ?? [];
+        } elseif (is_array($payloadRaw)) {
+            $payload = $payloadRaw;
+        }
+        if (!is_array($payload)) {
+            $this->module->SendDebug('MQTT', 'Invalid payload on topic ' . $topic, 0);
+            return;
+        }
+
+        $eventNode = isset($payload['event']) && is_array($payload['event']) ? $payload['event'] : null;
+        $pushNode = isset($payload['push']) && is_array($payload['push']) ? $payload['push'] : null;
+        $topType = strtoupper((string)($payload['pushType'] ?? ($payload['type'] ?? '')));
+
+        if ($eventNode || $topType === 'DEVICE_STATUS') {
+            $node = $eventNode ?: $payload;
+            $deviceId = (string)($node['deviceId'] ?? ($node['device_id'] ?? ''));
+            $report = $node['report'] ?? null;
+            if ($deviceId !== '' && is_array($report)) {
+                $this->pipeline->dispatchEvent($deviceId, $report);
+            }
+            return;
+        }
+
+        if ($pushNode || in_array($topType, ['DEVICE_REGISTERED', 'DEVICE_UNREGISTERED', 'DEVICE_ALIAS_CHANGED', 'DEVICE_PUSH'], true)) {
+            $node = $pushNode ?: $payload;
+            $type = strtoupper((string)($node['pushType'] ?? $topType));
+            $deviceId = (string)($node['deviceId'] ?? ($node['device_id'] ?? ''));
+            if ($deviceId !== '') {
+                $this->pipeline->dispatchMeta($type, $deviceId, is_array($node) ? $node : []);
+            }
+            return;
+        }
+
+        $this->module->SendDebug('MQTT', 'Unknown message type on topic ' . $topic, 0);
+    }
+
+    /**
+     * @param array<string, mixed> $raw
+     * @return array<string, mixed>
+     */
+    private function extractEnvelope(array $raw): array
+    {
+        if (!isset($raw['Buffer'])) {
+            return $raw;
+        }
+        $env = $raw;
+        $buffer = $raw['Buffer'];
+        if (is_string($buffer)) {
+            $decoded = json_decode($buffer, true);
+            if (is_array($decoded)) {
+                $env = array_merge($env, $decoded);
+            }
+        } elseif (is_array($buffer)) {
+            $env = array_merge($env, $buffer);
+        }
+        return $env;
+    }
+
+    private function topicMatches(string $topic, string $filter): bool
+    {
+        $filter = trim($filter);
+        if ($filter === '') {
+            return true;
+        }
+        $escaped = preg_quote($filter, '/');
+        $pattern = '/^' . str_replace(['\\*', '\\#'], '.*', $escaped) . '$/i';
+        return (bool)preg_match($pattern, $topic);
+    }
+}

--- a/LG ThinQ/module.php
+++ b/LG ThinQ/module.php
@@ -1,691 +1,462 @@
 <?php
 
 declare(strict_types=1);
-	class LGThinQ extends IPSModule
-	{
-		// API Key aus LG ThinQ Connect SDK (öffentlich dokumentiert)
-		private const API_KEY = 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3';
-		// Data-Flow Interface GUID (muss mit module.json->implemented übereinstimmen)
-		private const DATA_FLOW_GUID = '{A1F438B3-2A68-4A2B-8FDB-7460F1B8B854}';
-		// Child interface GUID (muss mit Device/module.json->implemented übereinstimmen)
-		private const CHILD_INTERFACE_GUID = '{5E9D1B64-0F44-4F21-9D74-09C5BB90FB2F}';
-		// MQTT Client Module GUID (Symcon MQTT Client)
-		private const MQTT_MODULE_GUID = '{F7A0DD2E-7684-95C0-64C2-D2A9DC47577B}';
-
-		public function Create()
-		{
-			//Never delete this line!
-			parent::Create();
-
-			// Konfigurations-Properties
-			$this->RegisterPropertyString('AccessToken', '');
-			$this->RegisterPropertyString('CountryCode', 'DE');
-			$this->RegisterPropertyString('ClientID', '');
-			$this->RegisterPropertyBoolean('Debug', false);
-			// MQTT Push
-			$this->RegisterPropertyBoolean('UseMQTT', true);
-			$this->RegisterPropertyInteger('MQTTClientID', 0);
-			$this->RegisterPropertyString('MQTTTopicFilter', 'app/clients/*/push');
-			$this->RegisterPropertyBoolean('IgnoreRetained', true);
-
-			// Event API subscription config
-			$this->RegisterPropertyInteger('EventTTLHrs', 24); // 1..24
-			$this->RegisterPropertyInteger('EventRenewLeadMin', 5); // renew N minutes before expiry
-
-			// Attribute zur Laufzeit
-			$this->RegisterAttributeString('ClientID', '');
-			$this->RegisterAttributeString('Devices', '[]');
-			$this->RegisterAttributeString('EventSubscriptions', '{}'); // { deviceId: { "expiresAt": ts } }
-
-			// (Polling entfernt)
-
-			// Renew timer for Event API
-			$this->RegisterTimer('EventRenewTimer', 0, 'LGTQ_RenewEvents($_IPS[\'TARGET\']);');
-		}
-
-		public function Destroy()
-		{
-			//Never delete this line!
-			parent::Destroy();
-		}
-
-		public function ApplyChanges()
-		{
-			//Never delete this line!
-			parent::ApplyChanges();
-
-			// ClientID bereitstellen (Property hat Vorrang, sonst Attribut generieren)
-			$propClient = trim($this->ReadPropertyString('ClientID'));
-			$attrClient = trim($this->ReadAttributeString('ClientID'));
-			if ($propClient !== '') {
-				$this->WriteAttributeString('ClientID', $propClient);
-			} elseif ($attrClient === '') {
-				$this->WriteAttributeString('ClientID', $this->generateUUIDv4());
-			}
-
-			// (Polling entfernt)
-
-			// Status setzen
-			$ok = $this->validateConfig();
-			$this->SetStatus($ok ? 102 : 104);
-
-			// Legacy: Sicherstellen, dass ein evtl. vorhandener UpdateTimer deaktiviert ist
-			@ $this->SetTimerInterval('UpdateTimer', 0);
-
-			// MQTT Parent verbinden (optional) – respektiere manuelle Parent-Wahl ("Schnittstelle ändern")
-			if ((bool)$this->ReadPropertyBoolean('UseMQTT')) {
-				$inst = @IPS_GetInstance($this->InstanceID);
-				$parentID = is_array($inst) ? (int)($inst['ConnectionID'] ?? 0) : 0;
-				if ($parentID <= 0) {
-					// Nur wenn kein Parent gesetzt ist, an einen MQTT-Parent verbinden/erstellen
-					if (method_exists($this, 'ConnectParent')) {
-						$this->ConnectParent(self::MQTT_MODULE_GUID);
-					}
-				}
-			}
-
-			// Event Renew Timer konfigurieren
-			$ttlH = max(1, min(24, (int)$this->ReadPropertyInteger('EventTTLHrs')));
-			$leadM = max(1, min(59, (int)$this->ReadPropertyInteger('EventRenewLeadMin')));
-			$nextSec = max(60, $ttlH * 3600 - $leadM * 60);
-			$this->SetTimerInterval('EventRenewTimer', $ok ? ($nextSec * 1000) : 0);
-		}
-
-		public function MessageSink($TimeStamp, $SenderID, $Message, $Data)
-		{
-			parent::MessageSink($TimeStamp, $SenderID, $Message, $Data);
-		}
-
-		// -------------------- Öffentliche Funktionen (Form-Buttons) --------------------
-
-		// Exportiert als LGTQ_TestConnection($id)
-		public function TestConnection(): void
-		{
-			try {
-				$devices = $this->fetchDevices();
-				$count = is_array($devices) ? count($devices) : 0;
-				$this->SendDebug('TestConnection', 'Geräte gefunden: ' . $count, 0);
-				$this->SetStatus(102);
-				$message = 'Verbindung OK. Geräte: ' . $count;
-				echo $message; // Zeigt ein Meldungsfenster in der Konsole
-				$this->NotifyUser($message);
-			} catch (Exception $e) {
-				$this->SetStatus(104);
-				$this->SendDebug('TestConnection Error', $e->getMessage(), 0);
-				$message = 'Verbindung fehlgeschlagen: ' . $e->getMessage();
-				echo $message; // Zeigt ein Meldungsfenster in der Konsole
-				$this->NotifyUser($message);
-			}
-		}
-
-		// Exportiert als LGTQ_SyncDevices($id)
-		public function SyncDevices(): void
-		{
-			try {
-				$devices = $this->fetchDevices();
-				$this->WriteAttributeString('Devices', json_encode($devices));
-				$this->NotifyUser('Geräteliste aktualisiert: ' . count($devices) . ' Geräte.');
-			} catch (Exception $e) {
-				$this->SendDebug('SyncDevices Error', $e->getMessage(), 0);
-				$this->NotifyUser('Sync fehlgeschlagen: ' . $e->getMessage());
-			}
-		}
-
-		// Exportiert als LGTQ_Update($id)
-		public function Update(): void
-		{
-			try {
-				// Ab Symcon-Architektur: Bridge aktualisiert nur interne Daten, keine Geräte unter der Bridge
-				$devices = $this->fetchDevices();
-				$this->WriteAttributeString('Devices', json_encode($devices));
-				$this->SetStatus(102);
-			} catch (Exception $e) {
-				$this->SendDebug('Update Error', $e->getMessage(), 0);
-			}
-		}
-
-		// Exportiert als LGTQ_SubscribeAll($id)
-		public function SubscribeAll(): void
-		{
-			try {
-				// Ensure client-level push subscription for meta events (add/delete/nickname)
-				try { $this->request('POST', 'push/devices'); } catch (Exception $e) { $this->SendDebug('Push Clients Subscribe', $e->getMessage(), 0); }
-				// Fetch devices and persist
-				$devices = $this->fetchDevices();
-				$this->WriteAttributeString('Devices', json_encode($devices));
-				$okCnt = 0; $total = 0;
-				foreach ($devices as $d) {
-					$deviceId = (string)($d['deviceId'] ?? ($d['device_id'] ?? ''));
-					if ($deviceId === '') continue;
-					$total++;
-					if ($this->SubscribeDevice($deviceId, true, true)) { $okCnt++; }
-				}
-				$this->NotifyUser(sprintf('SubscribeAll: %d/%d Geräte abonniert', $okCnt, $total));
-			} catch (Exception $e) {
-				$this->SendDebug('SubscribeAll Error', $e->getMessage(), 0);
-				$this->NotifyUser('SubscribeAll fehlgeschlagen: ' . $e->getMessage());
-			}
-		}
-
-		// Exportiert als LGTQ_UnsubscribeAll($id)
-		public function UnsubscribeAll(): void
-		{
-			try {
-				$ids = [];
-				$subs = $this->readEventSubscriptions();
-				foreach (array_keys($subs) as $id) { if ($id !== '') { $ids[$id] = true; } }
-				$devs = json_decode((string)$this->ReadAttributeString('Devices'), true);
-				if (is_array($devs)) {
-					foreach ($devs as $d) { $id = (string)($d['deviceId'] ?? ($d['device_id'] ?? '')); if ($id !== '') { $ids[$id] = true; } }
-				}
-				$okCnt = 0; $total = count($ids);
-				foreach (array_keys($ids) as $deviceId) { if ($this->UnsubscribeDevice($deviceId, true, true)) { $okCnt++; } }
-				$this->writeEventSubscriptions([]);
-				// Optionally unsubscribe client-level push
-				try { $this->request('DELETE', 'push/devices'); } catch (Exception $e) { $this->SendDebug('Push Clients Unsubscribe', $e->getMessage(), 0); }
-				$this->NotifyUser(sprintf('UnsubscribeAll: %d/%d Geräte abgemeldet', $okCnt, $total));
-			} catch (Exception $e) {
-				$this->SendDebug('UnsubscribeAll Error', $e->getMessage(), 0);
-				$this->NotifyUser('UnsubscribeAll fehlgeschlagen: ' . $e->getMessage());
-			}
-		}
-
-		// Exportiert als LGTQ_RenewAll($id)
-		public function RenewAll(): void
-		{
-			try {
-				$subs = $this->readEventSubscriptions();
-				$okCnt = 0; $total = count($subs);
-				foreach (array_keys($subs) as $deviceId) { if ($deviceId !== '' && $this->eventSubscribeDevice((string)$deviceId)) { $okCnt++; } }
-				$this->NotifyUser(sprintf('RenewAll: %d/%d Event-Abos erneuert', $okCnt, $total));
-			} catch (Exception $e) {
-				$this->SendDebug('RenewAll Error', $e->getMessage(), 0);
-				$this->NotifyUser('RenewAll fehlgeschlagen: ' . $e->getMessage());
-			}
-		}
-
-		// -------------------- Interne Helfer --------------------
-
-		private function validateConfig(): bool
-		{
-			$token = trim($this->ReadPropertyString('AccessToken'));
-			$country = strtoupper(trim($this->ReadPropertyString('CountryCode')));
-			return $token !== '' && $country !== '';
-		}
-
-		private function getBaseUrl(string $country): string
-		{
-			$region = $this->getRegionFromCountry($country);
-			return 'https://api-' . strtolower($region) . '.lgthinq.com/';
-		}
-
-		private function getRegionFromCountry(string $country): string
-		{
-			$country = strtoupper($country);
-			// Minimales Mapping entsprechend ThinQ SDK (EIC/AIC/KIC)
-			$EIC = ['DE','AT','CH','FR','IT','ES','GB','IE','NL','BE','DK','SE','NO','FI','PL','PT','GR','CZ','HU','RO'];
-			$AIC = ['US','CA','AR','BR','CL','CO','MX','PE','UY','VE','PR'];
-			$KIC = ['JP','KR','AU','NZ','CN','HK','TW','SG','TH','VN','MY','ID','PH'];
-			if (in_array($country, $EIC, true)) return 'EIC';
-			if (in_array($country, $AIC, true)) return 'AIC';
-			return 'KIC';
-		}
-
-		private function generateMessageId(): string
-		{
-			$bytes = random_bytes(16);
-			$base = rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
-			return $base;
-		}
-
-		private function generateUUIDv4(): string
-		{
-			$data = random_bytes(16);
-			$data[6] = chr((ord($data[6]) & 0x0f) | 0x40);
-			$data[8] = chr((ord($data[8]) & 0x3f) | 0x80);
-			return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
-		}
-
-		private function request(string $method, string $endpoint, ?array $payload = null, array $extraHeaders = []): array
-		{
-			if (!$this->validateConfig()) {
-				throw new Exception('AccessToken oder CountryCode nicht konfiguriert.');
-			}
-			$token = trim($this->ReadPropertyString('AccessToken'));
-			$country = strtoupper(trim($this->ReadPropertyString('CountryCode')));
-			$clientId = trim($this->ReadAttributeString('ClientID'));
-			$baseUrl = $this->getBaseUrl($country);
-			$url = $baseUrl . ltrim($endpoint, '/');
-
-			$headers = [
-				'Authorization: Bearer ' . $token,
-				'x-country: ' . $country,
-				'x-message-id: ' . $this->generateMessageId(),
-				'x-client-id: ' . $clientId,
-				'x-api-key: ' . self::API_KEY,
-				'x-service-phase: OP',
-				'Content-Type: application/json'
-			];
-			foreach ($extraHeaders as $h) {
-				$headers[] = $h;
-			}
-
-			$method = strtoupper($method);
-			$body = ($method !== 'GET' && $payload !== null) ? json_encode($payload) : '';
-
-			$this->SendDebug('HTTP Request', $method . ' ' . $url, 0);
-			if ($this->ReadPropertyBoolean('Debug')) {
-				$this->SendDebug('HTTP Headers', json_encode($headers), 0);
-				if ($method !== 'GET') $this->SendDebug('HTTP Body', $body, 0);
-			}
-
-			// Stream-Context für HTTP Request aufbauen
-			$headersStr = implode("\r\n", $headers);
-			$httpOptions = [
-				'method' => $method,
-				'header' => $headersStr,
-				'ignore_errors' => true,
-				'timeout' => 15,
-				'protocol_version' => 1.1
-			];
-			if ($method !== 'GET') {
-				$httpOptions['content'] = $body;
-			}
-			$context = stream_context_create(['http' => $httpOptions]);
-
-			$result = @file_get_contents($url, false, $context);
-			if ($result === false || $result === null) {
-				$error = error_get_last();
-				throw new Exception('HTTP Fehler beim Aufruf von ' . $url . ': ' . ($error['message'] ?? 'unbekannt'));
-			}
-
-			// HTTP Status prüfen
-			$statusHeader = $http_response_header[0] ?? '';
-			$statusCode = 0;
-			if (preg_match('/HTTP\/[0-9.]+\s+(\d+)/', $statusHeader, $m)) {
-				$statusCode = (int)$m[1];
-			}
-
-			// Einige Endpunkte (z.B. Event-Subscription/Renew) liefern ggf. keinen JSON-Body (204/leer/null)
-			if ($statusCode === 204 || trim((string)$result) === '') {
-				return [];
-			}
-			$decoded = json_decode($result, true);
-			if ($statusCode >= 400) {
-				if (is_array($decoded) && isset($decoded['error'])) {
-					$code = $decoded['error']['code'] ?? 'unknown';
-					$message = $decoded['error']['message'] ?? 'unknown';
-					throw new Exception('HTTP ' . $statusCode . ' API Fehler ' . $code . ': ' . $message . ' (' . $url . ')');
-				}
-				// Nicht-JSON-Fehlerantwort: Rohtext anfügen (gekürzt)
-				$snippet = substr(preg_replace('/\s+/', ' ', (string)$result), 0, 300);
-				throw new Exception('HTTP ' . $statusCode . ' Fehler von ' . $url . ': ' . $snippet);
-			}
-			if (!is_array($decoded)) {
-				// Erfolgreiche, aber nicht-JSON Antwort → als leer interpretieren
-				return [];
-			}
-			// ThinQ Connect liefert typischerweise { response: ... }
-			return $decoded['response'] ?? $decoded;
-		}
-
-		// High-Level API Wrapper
-		public function GetDevices(): string
-		{
-			$devices = $this->fetchDevices();
-			return json_encode($devices, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-		}
-
-		public function GetDeviceStatus(string $DeviceID): string
-		{
-			$status = $this->fetchDeviceStatus($DeviceID);
-			return json_encode($status, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-		}
-
-		public function GetDeviceProfile(string $DeviceID): string
-		{
-			$profile = $this->request('GET', 'devices/' . rawurlencode($DeviceID) . '/profile');
-			return json_encode($profile, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-		}
-
-		public function ControlDevice(string $DeviceID, string $JSONPayload): bool
-		{
-			$payload = json_decode($JSONPayload, true);
-			if (!is_array($payload)) {
-				throw new Exception('ControlDevice: Ungültiges JSONPayload');
-			}
-			$this->request('POST', 'devices/' . rawurlencode($DeviceID) . '/control', $payload, ['x-conditional-control: false']);
-			return true;
-		}
-
-		public function GetEnergyUsage(string $DeviceID, string $Property, string $Period, string $StartDate, string $EndDate): string
-		{
-			$endpoint = sprintf('devices/energy/%s/usage?property=%s&period=%s&startDate=%s&endDate=%s',
-				rawurlencode($DeviceID), rawurlencode($Property), rawurlencode($Period), rawurlencode($StartDate), rawurlencode($EndDate)
-			);
-			$data = $this->request('GET', $endpoint);
-			return json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-		}
-
-		private function fetchDevices(): array
-		{
-			$data = $this->request('GET', 'devices');
-			// Normalisieren auf Liste
-			if (isset($data['devices']) && is_array($data['devices'])) {
-				return $data['devices'];
-			}
-			if (isset($data[0]) || empty($data)) {
-				return $data; // bereits Liste oder leer
-			}
-			return [$data];
-		}
-
-		private function fetchDeviceStatus(string $deviceId): array
-		{
-			return $this->request('GET', 'devices/' . rawurlencode($deviceId) . '/state');
-		}
-
-		// Bridge erstellt KEINEN Gerätebaum mehr
-
-		private function ensureCategory(int $parentId, string $ident, string $name): int
-		{
-			$existing = @IPS_GetObjectIDByIdent($ident, $parentId);
-			if ($existing && IPS_ObjectExists($existing)) {
-				if (IPS_GetName($existing) !== $name) {
-					IPS_SetName($existing, $name);
-				}
-				return $existing;
-			}
-			$cid = IPS_CreateCategory();
-			IPS_SetParent($cid, $parentId);
-			IPS_SetIdent($cid, $ident);
-			IPS_SetName($cid, $name);
-			return $cid;
-		}
-
-		private function ensureVariable(int $parentId, string $ident, string $name, int $type, string $profile = ''): int
-		{
-			$vid = @IPS_GetObjectIDByIdent($ident, $parentId);
-			if ($vid && IPS_ObjectExists($vid)) {
-				if (IPS_GetName($vid) !== $name) IPS_SetName($vid, $name);
-				if ($profile !== '' && IPS_GetVariable($vid)['VariableCustomProfile'] !== $profile) {
-					IPS_SetVariableCustomProfile($vid, $profile);
-				}
-				return $vid;
-			}
-			$vid = IPS_CreateVariable($type);
-			IPS_SetParent($vid, $parentId);
-			IPS_SetIdent($vid, $ident);
-			IPS_SetName($vid, $name);
-			if ($profile !== '') IPS_SetVariableCustomProfile($vid, $profile);
-			return $vid;
-		}
-
-		private function getObjectIdByIdent(int $parentId, string $ident): int
-		{
-			return @IPS_GetObjectIDByIdent($ident, $parentId);
-		}
-
-		private function NotifyUser(string $message): void
-		{
-			// Einfache Log-Ausgabe. Optional: Nachrichtensystem integrieren.
-			$this->LogMessage($message, KL_MESSAGE);
-		}
-
-		// -------------------- Datenfluss (Splitter) --------------------
-		public function ForwardData($JSONString)
-		{
-			$this->SendDebug('ForwardData', (string)$JSONString, 0);
-			$data = json_decode((string)$JSONString, true);
-			if (!is_array($data)) {
-				return json_encode(['success' => false, 'error' => 'invalid json']);
-			}
-			if (!isset($data['DataID']) || strtoupper((string)$data['DataID']) !== strtoupper(self::DATA_FLOW_GUID)) {
-				return json_encode(['success' => false, 'error' => 'unexpected data id']);
-			}
-			$buffer = $data['Buffer'] ?? [];
-			if (is_string($buffer)) {
-				$decoded = json_decode($buffer, true);
-				if (is_array($decoded)) {
-					$buffer = $decoded;
-				} else {
-					$buffer = [];
-				}
-			}
-			$action = (string)($buffer['Action'] ?? '');
-			try {
-				switch ($action) {
-					case 'GetDevices':
-						$devices = $this->fetchDevices();
-						return json_encode(['success' => true, 'devices' => $devices], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-					case 'GetProfile':
-						$deviceId = (string)($buffer['DeviceID'] ?? '');
-						if ($deviceId === '') {
-							return json_encode(['success' => false, 'error' => 'DeviceID missing']);
-						}
-						$profile = $this->request('GET', 'devices/' . rawurlencode($deviceId) . '/profile');
-						return json_encode(['success' => true, 'profile' => $profile], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-					case 'GetStatus':
-						$deviceId = (string)($buffer['DeviceID'] ?? '');
-						if ($deviceId === '') {
-							return json_encode(['success' => false, 'error' => 'DeviceID missing']);
-						}
-						$status = $this->fetchDeviceStatus($deviceId);
-						return json_encode(['success' => true, 'status' => $status], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-					case 'Control':
-						$deviceId = (string)($buffer['DeviceID'] ?? '');
-						$payload = $buffer['Payload'] ?? null;
-						if ($deviceId === '' || !is_array($payload)) {
-							return json_encode(['success' => false, 'error' => 'invalid control parameters']);
-						}
-						$res = $this->request('POST', 'devices/' . rawurlencode($deviceId) . '/control', $payload, ['x-conditional-control: false']);
-						return json_encode(['success' => true, 'response' => $res], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-					case 'SubscribeDevice':
-						$deviceId = (string)($buffer['DeviceID'] ?? '');
-						$withPush = (bool)($buffer['Push'] ?? true);
-						$withEvent = (bool)($buffer['Event'] ?? true);
-						if ($deviceId === '') return json_encode(['success' => false, 'error' => 'DeviceID missing']);
-						$ok = $this->SubscribeDevice($deviceId, $withPush, $withEvent);
-						return json_encode(['success' => $ok]);
-					case 'UnsubscribeDevice':
-						$deviceId = (string)($buffer['DeviceID'] ?? '');
-						$fromPush = (bool)($buffer['Push'] ?? true);
-						$fromEvent = (bool)($buffer['Event'] ?? true);
-						if ($deviceId === '') return json_encode(['success' => false, 'error' => 'DeviceID missing']);
-						$ok = $this->UnsubscribeDevice($deviceId, $fromPush, $fromEvent);
-						return json_encode(['success' => $ok]);
-					case 'RenewEventForDevice':
-						$deviceId = (string)($buffer['DeviceID'] ?? '');
-						if ($deviceId === '') return json_encode(['success' => false, 'error' => 'DeviceID missing']);
-						$ok = $this->eventSubscribeDevice($deviceId);
-						return json_encode(['success' => $ok]);
-					default:
-						return json_encode(['success' => false, 'error' => 'unknown action']);
-				}
-			} catch (\Exception $e) {
-				$this->SendDebug('ForwardData Error', $e->getMessage(), 0);
-				return json_encode(['success' => false, 'error' => $e->getMessage()]);
-			}
-		}
-
-		public function ReceiveData($JSONString)
-		{
-			$this->SendDebug('ReceiveData', (string)$JSONString, 0);
-			$raw = json_decode((string)$JSONString, true);
-			if (!is_array($raw)) {
-				return '';
-			}
-			// MQTT Envelope extrahieren
-			$env = $raw;
-			if (isset($raw['Buffer'])) {
-				$buf = $raw['Buffer'];
-				if (is_string($buf)) {
-					$dec = json_decode($buf, true);
-					if (is_array($dec)) { $env = array_merge($env, $dec); }
-				} elseif (is_array($buf)) {
-					$env = array_merge($env, $buf);
-				}
-			}
-			$topic = (string)($env['Topic'] ?? ($env['topic'] ?? ''));
-			$payloadRaw = $env['Payload'] ?? ($env['payload'] ?? null);
-			$retain = (bool)($env['Retain'] ?? ($env['retain'] ?? false));
-
-			if ((bool)$this->ReadPropertyBoolean('IgnoreRetained') && $retain) {
-				$this->SendDebug('MQTT', 'Ignore retained: ' . $topic, 0);
-				return '';
-			}
-
-			$filter = (string)$this->ReadPropertyString('MQTTTopicFilter');
-			if ($filter !== '' && !$this->topicMatches($topic, $filter)) {
-				return '';
-			}
-
-			$payload = [];
-			if (is_string($payloadRaw)) {
-				$payload = json_decode((string)$payloadRaw, true);
-			} elseif (is_array($payloadRaw)) {
-				$payload = $payloadRaw;
-			}
-			if (!is_array($payload)) {
-				$this->SendDebug('MQTT', 'Invalid payload on topic ' . $topic, 0);
-				return '';
-			}
-
-			// Normalize payload nodes
-			$eventNode = isset($payload['event']) && is_array($payload['event']) ? $payload['event'] : null;
-			$pushNode  = isset($payload['push'])  && is_array($payload['push'])  ? $payload['push']  : null;
-			$topType   = strtoupper((string)($payload['pushType'] ?? ($payload['type'] ?? '')));
-
-			// Handle Event message (DEVICE_STATUS)
-			if ($eventNode || $topType === 'DEVICE_STATUS') {
-				$node = $eventNode ?: $payload;
-				$deviceId = (string)($node['deviceId'] ?? ($node['device_id'] ?? ''));
-				$report = $node['report'] ?? null;
-				if ($deviceId !== '' && is_array($report)) {
-					$this->SendDataToChildren(json_encode([
-						'DataID' => self::CHILD_INTERFACE_GUID,
-						'Buffer' => json_encode([
-							'Action' => 'Event',
-							'DeviceID' => $deviceId,
-							'Event' => $report
-						], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
-					]));
-				}
-				return '';
-			}
-
-			// Handle Push meta messages (DEVICE_REGISTERED/UNREGISTERED/...)
-			if ($pushNode || in_array($topType, ['DEVICE_REGISTERED', 'DEVICE_UNREGISTERED', 'DEVICE_ALIAS_CHANGED', 'DEVICE_PUSH'], true)) {
-				$node = $pushNode ?: $payload;
-				$pType = strtoupper((string)($node['pushType'] ?? ''));
-				$deviceId = (string)($node['deviceId'] ?? ($node['device_id'] ?? ''));
-				if ($deviceId !== '') {
-					if ($pType === 'DEVICE_REGISTERED') {
-						try { $this->SubscribeDevice($deviceId, true, true); } catch (\Throwable $e) { $this->SendDebug('PushAutoSubscribe Error', $e->getMessage(), 0); }
-					} elseif ($pType === 'DEVICE_UNREGISTERED') {
-						try { $this->UnsubscribeDevice($deviceId, true, true); } catch (\Throwable $e) { $this->SendDebug('PushAutoUnsubscribe Error', $e->getMessage(), 0); }
-					}
-				}
-				return '';
-			}
-
-			// Unknown payload type
-			$this->SendDebug('MQTT', 'Unknown message type on topic ' . $topic, 0);
-			return '';
-		}
-
-		private function topicMatches(string $topic, string $filter): bool
-		{
-			$filter = trim($filter);
-			if ($filter === '') return true;
-			$escaped = preg_quote($filter, '/');
-			$pattern = '/^' . str_replace(['\\*', '\\#'], '.*', $escaped) . '$/i';
-			return (bool)preg_match($pattern, $topic);
-		}
-
-		// -------------------- Event/Push Subscription Management --------------------
-
-		public function SubscribeDevice(string $DeviceID, bool $Push = true, bool $Event = true): bool
-		{
-			$ok = true;
-			if ($Event) {
-				$ok = $this->eventSubscribeDevice($DeviceID) && $ok;
-			}
-			if ($Push) {
-				try { $this->request('POST', 'push/' . rawurlencode($DeviceID) . '/subscribe'); } catch (\Exception $e) { $this->SendDebug('Push Subscribe Error', $e->getMessage(), 0); $ok = false; }
-			}
-			return $ok;
-		}
-
-		public function UnsubscribeDevice(string $DeviceID, bool $Push = true, bool $Event = true): bool
-		{
-			$ok = true;
-			if ($Event) {
-				try { $this->request('DELETE', 'event/' . rawurlencode($DeviceID) . '/unsubscribe'); } catch (\Exception $e) { $this->SendDebug('Event Unsubscribe Error', $e->getMessage(), 0); $ok = false; }
-				$this->removeEventSubscription($DeviceID);
-			}
-			if ($Push) {
-				try { $this->request('DELETE', 'push/' . rawurlencode($DeviceID) . '/unsubscribe'); } catch (\Exception $e) { $this->SendDebug('Push Unsubscribe Error', $e->getMessage(), 0); $ok = false; }
-			}
-			return $ok;
-		}
-
-		public function RenewEvents(): void
-		{
-			try {
-				$now = time();
-				$ttlH = max(1, min(24, (int)$this->ReadPropertyInteger('EventTTLHrs')));
-				$leadM = max(1, min(59, (int)$this->ReadPropertyInteger('EventRenewLeadMin')));
-				$leadSec = $leadM * 60;
-				$expiresAtDefault = $now + ($ttlH * 3600);
-				$subs = $this->readEventSubscriptions();
-				foreach (array_keys($subs) as $deviceId) {
-					$deviceId = (string)$deviceId;
-					if ($deviceId === '') continue;
-					$exp = (int)($subs[$deviceId]['expiresAt'] ?? 0);
-					if ($exp === 0 || ($exp - $leadSec) <= $now) {
-						if ($this->eventSubscribeDevice($deviceId)) {
-							$subs[$deviceId]['expiresAt'] = $expiresAtDefault;
-						}
-					}
-				}
-				$this->writeEventSubscriptions($subs);
-			} catch (\Throwable $e) {
-				$this->SendDebug('RenewEvents Error', $e->getMessage(), 0);
-			}
-		}
-
-		private function eventSubscribeDevice(string $deviceId): bool
-		{
-			$ttlH = max(1, min(24, (int)$this->ReadPropertyInteger('EventTTLHrs')));
-			$body = ['expire' => ['unit' => 'HOUR', 'timer' => $ttlH]];
-			try {
-				$this->request('POST', 'event/' . rawurlencode($deviceId) . '/subscribe', $body);
-				$subs = $this->readEventSubscriptions();
-				$subs[$deviceId]['expiresAt'] = time() + ($ttlH * 3600);
-				$this->writeEventSubscriptions($subs);
-				return true;
-			} catch (\Exception $e) {
-				$this->SendDebug('Event Subscribe Error', $e->getMessage(), 0);
-				return false;
-			}
-		}
-
-		private function readEventSubscriptions(): array
-		{
-			$raw = (string)$this->ReadAttributeString('EventSubscriptions');
-			$dec = json_decode($raw, true);
-			return is_array($dec) ? $dec : [];
-		}
-
-		private function writeEventSubscriptions(array $subs): void
-		{
-			$this->WriteAttributeString('EventSubscriptions', json_encode($subs));
-		}
-
-		private function removeEventSubscription(string $deviceId): void
-		{
-			$subs = $this->readEventSubscriptions();
-			if (isset($subs[$deviceId])) { unset($subs[$deviceId]); $this->writeEventSubscriptions($subs); }
-		}
-	}
+
+require_once __DIR__ . '/libs/ThinQHelpers.php';
+require_once __DIR__ . '/libs/ThinQConfig.php';
+require_once __DIR__ . '/libs/ThinQDeviceRepository.php';
+require_once __DIR__ . '/libs/ThinQEventSubscriptionRepository.php';
+require_once __DIR__ . '/libs/ThinQHttpClient.php';
+require_once __DIR__ . '/libs/ThinQEventManager.php';
+require_once __DIR__ . '/libs/ThinQEventPipeline.php';
+require_once __DIR__ . '/libs/ThinQMqttRouter.php';
+
+class LGThinQ extends IPSModule
+{
+    public const API_KEY = 'v6GFvkweNo7DK7yD3ylIZ9w52aKBU0eJ7wLXkSR3';
+    private const DATA_FLOW_GUID = '{A1F438B3-2A68-4A2B-8FDB-7460F1B8B854}';
+    private const CHILD_INTERFACE_GUID = '{5E9D1B64-0F44-4F21-9D74-09C5BB90FB2F}';
+    private const MQTT_MODULE_GUID = '{F7A0DD2E-7684-95C0-64C2-D2A9DC47577B}';
+
+    private ?ThinQBridgeConfig $config = null;
+    private ?ThinQHttpClient $httpClient = null;
+    private ?ThinQDeviceRepository $deviceRepository = null;
+    private ?ThinQEventSubscriptionRepository $subscriptionRepository = null;
+    private ?ThinQEventManager $eventManager = null;
+    private ?ThinQEventPipeline $eventPipeline = null;
+    private ?ThinQMqttRouter $mqttRouter = null;
+
+    public function Create()
+    {
+        parent::Create();
+
+        $this->RegisterPropertyString('AccessToken', '');
+        $this->RegisterPropertyString('CountryCode', 'DE');
+        $this->RegisterPropertyString('ClientID', '');
+        $this->RegisterPropertyBoolean('Debug', false);
+        $this->RegisterPropertyBoolean('UseMQTT', true);
+        $this->RegisterPropertyInteger('MQTTClientID', 0);
+        $this->RegisterPropertyString('MQTTTopicFilter', 'app/clients/*/push');
+        $this->RegisterPropertyBoolean('IgnoreRetained', true);
+        $this->RegisterPropertyInteger('EventTTLHrs', 24);
+        $this->RegisterPropertyInteger('EventRenewLeadMin', 5);
+
+        $this->RegisterAttributeString('ClientID', '');
+        $this->RegisterAttributeString('Devices', '[]');
+        $this->RegisterAttributeString('EventSubscriptions', '{}');
+
+        $this->RegisterTimer('EventRenewTimer', 0, 'LGTQ_RenewEvents($_IPS[\'TARGET\']);');
+    }
+
+    public function ApplyChanges()
+    {
+        parent::ApplyChanges();
+        $this->bootServices();
+
+        $errors = $this->config->validate();
+        if (!empty($errors)) {
+            $this->SetStatus(104);
+            foreach ($errors as $error) {
+                $this->SendDebug('Config', $error, 0);
+            }
+        } else {
+            $this->SetStatus(102);
+        }
+
+        $this->ensureMqttParent();
+        $this->configureTimers();
+    }
+
+    public function ForwardData($JSONString)
+    {
+        $this->ensureBooted();
+        $this->SendDebug('ForwardData', (string)$JSONString, 0);
+        $json = json_decode((string)$JSONString, true);
+        if (!is_array($json)) {
+            return json_encode(['success' => false, 'error' => 'invalid payload']);
+        }
+        $buffer = $json['Buffer'] ?? [];
+        if (is_string($buffer)) {
+            $buffer = json_decode($buffer, true);
+        }
+        if (!is_array($buffer)) {
+            $buffer = [];
+        }
+
+        $action = (string)($buffer['Action'] ?? '');
+        try {
+            switch ($action) {
+                case 'GetDevices':
+                    $devices = $this->fetchDevices();
+                    return json_encode(['success' => true, 'devices' => $devices], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                case 'GetStatus':
+                    $deviceId = (string)($buffer['DeviceID'] ?? '');
+                    if ($deviceId === '') {
+                        throw new Exception('DeviceID missing');
+                    }
+                    $status = $this->fetchDeviceStatus($deviceId);
+                    return json_encode(['success' => true, 'status' => $status], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                case 'GetProfile':
+                    $deviceId = (string)($buffer['DeviceID'] ?? '');
+                    if ($deviceId === '') {
+                        throw new Exception('DeviceID missing');
+                    }
+                    $profile = $this->httpClient->request('GET', 'devices/' . rawurlencode($deviceId) . '/profile');
+                    return json_encode(['success' => true, 'profile' => $profile], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                case 'Control':
+                    $deviceId = (string)($buffer['DeviceID'] ?? '');
+                    $payload = $buffer['Payload'] ?? null;
+                    if ($deviceId === '' || !is_array($payload)) {
+                        throw new Exception('Control payload invalid');
+                    }
+                    $response = $this->httpClient->request('POST', 'devices/' . rawurlencode($deviceId) . '/control', $payload, ['x-conditional-control: false']);
+                    return json_encode(['success' => true, 'response' => $response], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                case 'SubscribeDevice':
+                    $deviceId = (string)($buffer['DeviceID'] ?? '');
+                    $withPush = (bool)($buffer['Push'] ?? true);
+                    $withEvent = (bool)($buffer['Event'] ?? true);
+                    if ($deviceId === '') {
+                        throw new Exception('DeviceID missing');
+                    }
+                    $ok = $this->SubscribeDevice($deviceId, $withPush, $withEvent);
+                    return json_encode(['success' => $ok], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                case 'UnsubscribeDevice':
+                    $deviceId = (string)($buffer['DeviceID'] ?? '');
+                    $fromPush = (bool)($buffer['Push'] ?? true);
+                    $fromEvent = (bool)($buffer['Event'] ?? true);
+                    if ($deviceId === '') {
+                        throw new Exception('DeviceID missing');
+                    }
+                    $ok = $this->UnsubscribeDevice($deviceId, $fromPush, $fromEvent);
+                    return json_encode(['success' => $ok], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                case 'RenewEventForDevice':
+                    $deviceId = (string)($buffer['DeviceID'] ?? '');
+                    if ($deviceId === '') {
+                        throw new Exception('DeviceID missing');
+                    }
+                    $ok = $this->eventManager->subscribe($deviceId);
+                    return json_encode(['success' => $ok], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                default:
+                    return json_encode(['success' => false, 'error' => 'unknown action']);
+            }
+        } catch (Throwable $e) {
+            $this->SendDebug('ForwardData Error', $e->getMessage(), 0);
+            return json_encode(['success' => false, 'error' => $e->getMessage()]);
+        }
+    }
+
+    public function ReceiveData($JSONString)
+    {
+        $this->ensureBooted();
+        $this->mqttRouter->handle((string)$JSONString);
+    }
+
+    public function TestConnection(): void
+    {
+        try {
+            $devices = $this->fetchDevices();
+            $count = count($devices);
+            $this->NotifyUser('Verbindung OK. Geräte: ' . $count);
+            $this->SetStatus(102);
+            echo 'Verbindung OK. Geräte: ' . $count;
+        } catch (Throwable $e) {
+            $this->SetStatus(104);
+            $this->SendDebug('TestConnection', $e->getMessage(), 0);
+            $this->NotifyUser('Verbindung fehlgeschlagen: ' . $e->getMessage());
+            echo 'Verbindung fehlgeschlagen: ' . $e->getMessage();
+        }
+    }
+
+    public function SyncDevices(): void
+    {
+        try {
+            $devices = $this->fetchDevices();
+            $this->deviceRepository->saveAll($devices);
+            $this->NotifyUser('Geräteliste aktualisiert: ' . count($devices) . ' Geräte.');
+        } catch (Throwable $e) {
+            $this->SendDebug('SyncDevices', $e->getMessage(), 0);
+            $this->NotifyUser('Sync fehlgeschlagen: ' . $e->getMessage());
+        }
+    }
+
+    public function Update(): void
+    {
+        try {
+            $devices = $this->fetchDevices();
+            $this->deviceRepository->saveAll($devices);
+        } catch (Throwable $e) {
+            $this->SendDebug('Update', $e->getMessage(), 0);
+        }
+    }
+
+    public function SubscribeAll(): void
+    {
+        try {
+            $devices = $this->fetchDevices();
+            $this->deviceRepository->saveAll($devices);
+            $ok = 0;
+            $total = 0;
+            foreach ($devices as $device) {
+                $deviceId = (string)($device['deviceId'] ?? ($device['device_id'] ?? ''));
+                if ($deviceId === '') {
+                    continue;
+                }
+                $total++;
+                if ($this->SubscribeDevice($deviceId, true, true)) {
+                    $ok++;
+                }
+            }
+            try {
+                $this->httpClient->request('POST', 'push/devices');
+            } catch (Throwable $e) {
+                $this->SendDebug('SubscribeAll Push', $e->getMessage(), 0);
+            }
+            $this->NotifyUser(sprintf('SubscribeAll: %d/%d Geräte abonniert', $ok, $total));
+        } catch (Throwable $e) {
+            $this->SendDebug('SubscribeAll', $e->getMessage(), 0);
+            $this->NotifyUser('SubscribeAll fehlgeschlagen: ' . $e->getMessage());
+        }
+    }
+
+    public function UnsubscribeAll(): void
+    {
+        try {
+            $ids = [];
+            foreach ($this->subscriptionRepository->getAll() as $deviceId => $_) {
+                if ($deviceId !== '') {
+                    $ids[$deviceId] = true;
+                }
+            }
+            foreach ($this->deviceRepository->getAll() as $device) {
+                $deviceId = (string)($device['deviceId'] ?? ($device['device_id'] ?? ''));
+                if ($deviceId !== '') {
+                    $ids[$deviceId] = true;
+                }
+            }
+            $ok = 0;
+            $total = count($ids);
+            foreach (array_keys($ids) as $deviceId) {
+                if ($this->UnsubscribeDevice((string)$deviceId, true, true)) {
+                    $ok++;
+                }
+            }
+            try {
+                $this->httpClient->request('DELETE', 'push/devices');
+            } catch (Throwable $e) {
+                $this->SendDebug('UnsubscribeAll Push', $e->getMessage(), 0);
+            }
+            $this->subscriptionRepository->saveAll([]);
+            $this->NotifyUser(sprintf('UnsubscribeAll: %d/%d Geräte abgemeldet', $ok, $total));
+        } catch (Throwable $e) {
+            $this->SendDebug('UnsubscribeAll', $e->getMessage(), 0);
+            $this->NotifyUser('UnsubscribeAll fehlgeschlagen: ' . $e->getMessage());
+        }
+    }
+
+    public function RenewAll(): void
+    {
+        try {
+            $subs = $this->subscriptionRepository->getAll();
+            $ok = 0;
+            $total = count($subs);
+            foreach (array_keys($subs) as $deviceId) {
+                if ($deviceId === '') {
+                    continue;
+                }
+                if ($this->eventManager->subscribe((string)$deviceId)) {
+                    $ok++;
+                }
+            }
+            $this->NotifyUser(sprintf('RenewAll: %d/%d Event-Abos erneuert', $ok, $total));
+        } catch (Throwable $e) {
+            $this->SendDebug('RenewAll', $e->getMessage(), 0);
+            $this->NotifyUser('RenewAll fehlgeschlagen: ' . $e->getMessage());
+        }
+    }
+
+    public function RenewEvents(): void
+    {
+        $this->ensureBooted();
+        try {
+            $this->eventManager->renewExpiring();
+        } catch (Throwable $e) {
+            $this->SendDebug('RenewEvents', $e->getMessage(), 0);
+        }
+    }
+
+    public function SubscribeDevice(string $DeviceID, bool $Push = true, bool $Event = true): bool
+    {
+        $this->ensureBooted();
+        $ok = true;
+        if ($Event) {
+            $ok = $this->eventManager->subscribe($DeviceID) && $ok;
+        }
+        if ($Push) {
+            try {
+                $this->httpClient->request('POST', 'push/' . rawurlencode($DeviceID) . '/subscribe');
+            } catch (Throwable $e) {
+                $this->SendDebug('Push Subscribe', $e->getMessage(), 0);
+                $ok = false;
+            }
+        }
+        return $ok;
+    }
+
+    public function UnsubscribeDevice(string $DeviceID, bool $Push = true, bool $Event = true): bool
+    {
+        $this->ensureBooted();
+        $ok = true;
+        if ($Event) {
+            $ok = $this->eventManager->unsubscribe($DeviceID) && $ok;
+        }
+        if ($Push) {
+            try {
+                $this->httpClient->request('DELETE', 'push/' . rawurlencode($DeviceID) . '/unsubscribe');
+            } catch (Throwable $e) {
+                $this->SendDebug('Push Unsubscribe', $e->getMessage(), 0);
+                $ok = false;
+            }
+        }
+        return $ok;
+    }
+
+    public function GetDevices(): string
+    {
+        $this->ensureBooted();
+        $devices = $this->fetchDevices();
+        return json_encode($devices, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    public function GetDeviceStatus(string $DeviceID): string
+    {
+        $this->ensureBooted();
+        $status = $this->fetchDeviceStatus($DeviceID);
+        return json_encode($status, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    public function GetDeviceProfile(string $DeviceID): string
+    {
+        $this->ensureBooted();
+        $profile = $this->httpClient->request('GET', 'devices/' . rawurlencode($DeviceID) . '/profile');
+        return json_encode($profile, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    public function ControlDevice(string $DeviceID, string $JSONPayload): bool
+    {
+        $this->ensureBooted();
+        $payload = json_decode($JSONPayload, true);
+        if (!is_array($payload)) {
+            throw new Exception('ControlDevice: ungültiges JSON');
+        }
+        $this->httpClient->request('POST', 'devices/' . rawurlencode($DeviceID) . '/control', $payload, ['x-conditional-control: false']);
+        return true;
+    }
+
+    private function bootServices(): void
+    {
+        $this->config = ThinQBridgeConfig::fromModule($this);
+        $this->deviceRepository = new ThinQDeviceRepository($this);
+        $this->subscriptionRepository = new ThinQEventSubscriptionRepository($this);
+        $this->httpClient = new ThinQHttpClient($this, $this->config, self::API_KEY);
+        $this->eventManager = new ThinQEventManager($this, $this->config, $this->httpClient, $this->subscriptionRepository);
+        $this->eventPipeline = new ThinQEventPipeline();
+        $this->eventPipeline->onEvent(function (string $deviceId, array $payload): void {
+            $this->SendDataToChildren(json_encode([
+                'DataID' => self::CHILD_INTERFACE_GUID,
+                'Buffer' => json_encode([
+                    'Action' => 'Event',
+                    'DeviceID' => $deviceId,
+                    'Event' => $payload
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        });
+        $this->eventPipeline->onMeta(function (string $type, string $deviceId, array $payload): void {
+            $this->handleMetaEvent($type, $deviceId, $payload);
+        });
+        $this->mqttRouter = new ThinQMqttRouter($this, $this->config, $this->eventPipeline);
+    }
+
+    private function ensureBooted(): void
+    {
+        if ($this->config === null || $this->httpClient === null || $this->eventManager === null || $this->mqttRouter === null) {
+            $this->bootServices();
+        }
+    }
+
+    private function configureTimers(): void
+    {
+        $ttl = $this->config->normalizedEventTtlHours();
+        $lead = $this->config->normalizedEventRenewLeadMinutes();
+        $interval = max(60, $ttl * 3600 - $lead * 60);
+        $errors = $this->config->validate();
+        $this->SetTimerInterval('EventRenewTimer', empty($errors) ? $interval * 1000 : 0);
+    }
+
+    private function ensureMqttParent(): void
+    {
+        if (!(bool)$this->ReadPropertyBoolean('UseMQTT')) {
+            return;
+        }
+        $inst = @IPS_GetInstance($this->InstanceID);
+        $parentId = is_array($inst) ? (int)($inst['ConnectionID'] ?? 0) : 0;
+        if ($parentId > 0) {
+            return;
+        }
+        if (method_exists($this, 'ConnectParent')) {
+            $this->ConnectParent(self::MQTT_MODULE_GUID);
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function fetchDevices(): array
+    {
+        $data = $this->httpClient->request('GET', 'devices');
+        if (isset($data['devices']) && is_array($data['devices'])) {
+            return $data['devices'];
+        }
+        if (empty($data)) {
+            return [];
+        }
+        if (isset($data[0])) {
+            return $data;
+        }
+        return [$data];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fetchDeviceStatus(string $deviceId): array
+    {
+        return $this->httpClient->request('GET', 'devices/' . rawurlencode($deviceId) . '/state');
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function handleMetaEvent(string $type, string $deviceId, array $payload): void
+    {
+        switch (strtoupper($type)) {
+            case 'DEVICE_REGISTERED':
+                $this->SendDebug('Push', 'Auto subscribe for ' . $deviceId, 0);
+                $this->SubscribeDevice($deviceId, true, true);
+                break;
+            case 'DEVICE_UNREGISTERED':
+                $this->SendDebug('Push', 'Auto unsubscribe for ' . $deviceId, 0);
+                $this->UnsubscribeDevice($deviceId, true, true);
+                break;
+            case 'DEVICE_ALIAS_CHANGED':
+            case 'DEVICE_PUSH':
+            default:
+                $this->SendDebug('Push', 'Meta event ' . $type . ' for ' . $deviceId, 0);
+                break;
+        }
+    }
+
+    private function NotifyUser(string $message): void
+    {
+        $this->LogMessage($message, KL_MESSAGE);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the LG ThinQ bridge into a modular service architecture with dedicated HTTP client, repositories and event management
- add a reusable MQTT router and event pipeline to normalise push handling and auto-subscriptions
- drive capability selection from a JSON catalogue and improve error logging in the device module

## Testing
- php -l "LG ThinQ/module.php"
- php -l "LG ThinQ Device/module.php"
- php -l "LG ThinQ Device/libs/CapabilityEngine.php"
- for f in 'LG ThinQ/libs/'*.php; do php -l "$f"; done


------
https://chatgpt.com/codex/tasks/task_e_68d38fc10d04832a8831b330a6058e5c