### PR TITLE
Fix ThinQ config creation outside module context

### DIFF
--- a/LG ThinQ/libs/ThinQConfig.php
+++ b/LG ThinQ/libs/ThinQConfig.php
@@ -42,28 +42,18 @@ final class ThinQBridgeConfig
         $this->eventRenewLeadMin = $eventRenewLeadMin;
     }
 
-    public static function fromModule(IPSModule $module): self
-    {
-        $accessToken = trim((string)$module->ReadPropertyString('AccessToken'));
-        $countryCode = strtoupper(trim((string)$module->ReadPropertyString('CountryCode')));
-        $debug = (bool)$module->ReadPropertyBoolean('Debug');
-        $useMqtt = (bool)$module->ReadPropertyBoolean('UseMQTT');
-        $mqttClientId = (int)$module->ReadPropertyInteger('MQTTClientID');
-        $mqttTopicFilter = (string)$module->ReadPropertyString('MQTTTopicFilter');
-        $ignoreRetained = (bool)$module->ReadPropertyBoolean('IgnoreRetained');
-        $eventTtlHours = (int)$module->ReadPropertyInteger('EventTTLHrs');
-        $eventRenewLeadMin = (int)$module->ReadPropertyInteger('EventRenewLeadMin');
-
-        $clientIdProperty = trim((string)$module->ReadPropertyString('ClientID'));
-        $clientIdAttr = trim((string)$module->ReadAttributeString('ClientID'));
-        $clientId = $clientIdProperty !== '' ? $clientIdProperty : $clientIdAttr;
-        if ($clientId === '') {
-            $clientId = ThinQHelpers::generateUUIDv4();
-            $module->WriteAttributeString('ClientID', $clientId);
-        } elseif ($clientIdProperty !== '' && $clientIdProperty !== $clientIdAttr) {
-            $module->WriteAttributeString('ClientID', $clientIdProperty);
-        }
-
+    public static function create(
+        string $accessToken,
+        string $countryCode,
+        string $clientId,
+        bool $debug,
+        bool $useMqtt,
+        int $mqttClientId,
+        string $mqttTopicFilter,
+        bool $ignoreRetained,
+        int $eventTtlHours,
+        int $eventRenewLeadMin
+    ): self {
         return new self(
             $accessToken,
             $countryCode,


### PR DESCRIPTION
## Summary
- move the ThinQ bridge configuration bootstrap into the LGThinQ module so protected accessors can be used safely
- add a dedicated ThinQBridgeConfig::create factory for value-based instantiation

## Testing
- php -l 'LG ThinQ/libs/ThinQConfig.php'
- php -l 'LG ThinQ/module.php'

------
https://chatgpt.com/codex/tasks/task_e_68d418a07bd0832aa971b9b2528f3086